### PR TITLE
Batch Add to Collection: Make the header style consistent & Remove invalid link class

### DIFF
--- a/musicbrainz-batch-add-to-collection.user.js
+++ b/musicbrainz-batch-add-to-collection.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name              MusicBrainz Batch Add to Collection
 // @namespace         https://github.com/y-young/userscripts
-// @version           2021.8.25
+// @version           2021.8.25.1
 // @description       Batch add entities to MusicBrainz collection and copy MBIDs from entity pages, search result or existing collections.
 // @author            y-young
 // @licence           MIT; https://opensource.org/licenses/MIT
@@ -258,12 +258,12 @@ function toggleSelection(event) {
 }
 
 function createToggleSelectionCheckbox() {
-    const headCell = document.createElement("td");
+    const headCell = document.createElement("th");
     const checkbox = document.createElement("input");
     checkbox.setAttribute("type", "checkbox");
     checkbox.addEventListener("click", toggleSelection);
     headCell.appendChild(checkbox);
-    headCell.style.width = "1em";
+    headCell.className = "checkbox-cell";
     return headCell;
 }
 

--- a/musicbrainz-batch-add-to-collection.user.js
+++ b/musicbrainz-batch-add-to-collection.user.js
@@ -233,7 +233,7 @@ function loadCollections() {
                     </tr>`).join('')}
                     <tr>
                         <td>
-                            <a class="external" href="/collection/create" target="_blank" rel="noreferrer">
+                            <a href="/collection/create" target="_blank" rel="noreferrer">
                                 Create a new collection
                             </a>
                         </td>


### PR DESCRIPTION
First of all, I wanted to say that I really like your userscript because it finally gives me the possibility to enter my collections more efficiently. So far I have been post-poning this task until there would be a better way to add/move many items in one go and only added few items every now and then. Basically I thought that I would probably have to implement something like this myself one day 😅

Therfore I have immediately installed and tested this script and spotted two minor issues:
- The header cells for the checkboxes which are injected by the script look slightly different than the standard ones. I have changed them to use the same selectors which are used by MBS on artist and RG pages.
- Creating a new collection links to an internal page for which there should not be an "external link" icon, the "new tab" icon is sufficient. I have removed the invalid link class.